### PR TITLE
Add servings field to recipe response for CI testing

### DIFF
--- a/src/controllers/recipes/getRecipe.ts
+++ b/src/controllers/recipes/getRecipe.ts
@@ -44,6 +44,7 @@ export async function getRecipe(req, res) {
       ],
       image: "https://www.budgetbytes.com/wp-content/uploads/2022/07/Chicken-Alfredo-bowl.jpg",
       difficulty: "Easy", // Added new field for CI test
+      servings: 4, // New feature field for CI test
     }, res);
 
   } catch (error) {


### PR DESCRIPTION
Added a new field, servings, to the recipe response in the getRecipe controller.
This field indicates the number of servings for the recipe (set to 4).
This change is intended to test the CI pipeline and demonstrate feature addition workflow.